### PR TITLE
Handle pylint failures gracefully

### DIFF
--- a/src/scanner.py
+++ b/src/scanner.py
@@ -66,18 +66,24 @@ class AcSecurity:
     def check_code_quality(self):
         """Run pylint to check code quality issues."""
         logging.info("Checking code quality...")
-        result = subprocess.run(
-            ['pylint', '--rcfile=.pylintrc', self.app_path],
-            capture_output=True,
-            text=True,
-            check=True
-        )
+        try:
+            result = subprocess.run(
+                ['pylint', '--rcfile=.pylintrc', self.app_path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError as e:
+            self.vulnerabilities.append(f"Error running pylint: {e}")
+            return
+
         if result.returncode == 0:
             self.vulnerabilities.append("No code quality issues found.")
         elif result.returncode in (28,):  # Adjust as needed for specific exit codes
             self.vulnerabilities.append(f"Code quality issues (non-fatal):\n{result.stdout.strip()}")
         else:
-            self.vulnerabilities.append(f"Code quality issues found:\n{result.stdout.strip()}")
+            output = result.stdout.strip() or result.stderr.strip()
+            self.vulnerabilities.append(f"Code quality issues found:\n{output}")
 
     def write_issues_to_file(self):
         """Write the found vulnerabilities and issues to issues.txt file with suggestions for fixing."""

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,7 +1,10 @@
 from src.scanner import AcSecurity
-import pylint
+from pathlib import Path
+import pylint  # ensure dependency is installed
 
-scanner = AcSecurity('C:/Users/Cable/Documents/GitHub/CGS/AcSecurity/tests')
+# Use the directory containing this test file so the tests run on any machine
+tests_dir = Path(__file__).resolve().parent
+scanner = AcSecurity(str(tests_dir))
 vulnerabilities = scanner.scan()
 
 ## Copyright (C) 2024  Austin Cabler


### PR DESCRIPTION
## Summary
- Avoid raising exceptions when pylint reports errors and capture output for the vulnerability report
- Use repository-relative test path so scanner works cross-platform

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1d1fc0a808332acca8f1ed7437bca